### PR TITLE
🐛 Issue #5: microbundle mangles the css class names

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8714,6 +8714,24 @@
       "resolved": "https://artifactory.corp.adobe.com:443/artifactory/api/npm/npmjs/camelcase-css/-/camelcase-css-2.0.1.tgz",
       "integrity": "sha1-7pePaUeRTMMMa0R0G27R338EP9U="
     },
+    "camelcase-keys": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
+      "integrity": "sha1-MIvur/3ygRkFHvodkyITyRuPkuc=",
+      "dev": true,
+      "requires": {
+        "camelcase": "^2.0.0",
+        "map-obj": "^1.0.0"
+      },
+      "dependencies": {
+        "camelcase": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz",
+          "integrity": "sha1-fB0W1nmhu+WcoCys7PsBHiAfWh8=",
+          "dev": true
+        }
+      }
+    },
     "can-use-dom": {
       "version": "0.1.0",
       "resolved": "https://artifactory.corp.adobe.com:443/artifactory/api/npm/npm-adobe-release/can-use-dom/-/can-use-dom-0.1.0.tgz",
@@ -16593,6 +16611,12 @@
       "resolved": "https://artifactory.corp.adobe.com:443/artifactory/api/npm/npmjs/is-extglob/-/is-extglob-2.1.1.tgz",
       "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI="
     },
+    "is-finite": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.1.0.tgz",
+      "integrity": "sha512-cdyMtqX/BOqqNBBiKlIVkytNHm49MtMlYyn1zxzvJKWmFMlGzm+ry5BBfYyeY9YmNKbRSo/o7OX9w9ale0wg3w==",
+      "dev": true
+    },
     "is-fullwidth-code-point": {
       "version": "3.0.0",
       "resolved": "https://artifactory.corp.adobe.com:443/artifactory/api/npm/npmjs/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
@@ -16861,6 +16885,12 @@
       "version": "1.2.4",
       "resolved": "https://artifactory.corp.adobe.com:443/artifactory/api/npm/npmjs/is-url/-/is-url-1.2.4.tgz",
       "integrity": "sha1-BKTfRtKMTP89c9Af8Gq+sxihqlI="
+    },
+    "is-utf8": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
+      "integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI=",
+      "dev": true
     },
     "is-valid-path": {
       "version": "0.1.1",
@@ -18311,6 +18341,12 @@
       "resolved": "https://artifactory.corp.adobe.com:443/artifactory/api/npm/npmjs/map-cache/-/map-cache-0.2.2.tgz",
       "integrity": "sha1-wyq9C9ZSXZsFFkW7TyasXcmKDb8="
     },
+    "map-obj": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
+      "integrity": "sha1-2TPOuSBdgr3PSIb2dCvcK03qFG0=",
+      "dev": true
+    },
     "map-or-similar": {
       "version": "1.5.0",
       "resolved": "https://artifactory.corp.adobe.com:443/artifactory/api/npm/npm-adobe-release/map-or-similar/-/map-or-similar-1.5.0.tgz",
@@ -18589,6 +18625,109 @@
       "resolved": "https://artifactory.corp.adobe.com:443/artifactory/api/npm/npmjs/memorystream/-/memorystream-0.3.1.tgz",
       "integrity": "sha1-htcJCzDORV1j+64S3aUaR93K+bI=",
       "dev": true
+    },
+    "meow": {
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
+      "integrity": "sha1-cstmi0JSKCkKu/qFaJJYcwioAfs=",
+      "dev": true,
+      "requires": {
+        "camelcase-keys": "^2.0.0",
+        "decamelize": "^1.1.2",
+        "loud-rejection": "^1.0.0",
+        "map-obj": "^1.0.1",
+        "minimist": "^1.1.3",
+        "normalize-package-data": "^2.3.4",
+        "object-assign": "^4.0.1",
+        "read-pkg-up": "^1.0.1",
+        "redent": "^1.0.0",
+        "trim-newlines": "^1.0.0"
+      },
+      "dependencies": {
+        "find-up": {
+          "version": "1.1.2",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
+          "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
+          "dev": true,
+          "requires": {
+            "path-exists": "^2.0.0",
+            "pinkie-promise": "^2.0.0"
+          }
+        },
+        "load-json-file": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
+          "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "^4.1.2",
+            "parse-json": "^2.2.0",
+            "pify": "^2.0.0",
+            "pinkie-promise": "^2.0.0",
+            "strip-bom": "^2.0.0"
+          }
+        },
+        "loud-rejection": {
+          "version": "1.6.0",
+          "resolved": "https://registry.npmjs.org/loud-rejection/-/loud-rejection-1.6.0.tgz",
+          "integrity": "sha1-W0b4AUft7leIcPCG0Eghz5mOVR8=",
+          "dev": true,
+          "requires": {
+            "currently-unhandled": "^0.4.1",
+            "signal-exit": "^3.0.0"
+          }
+        },
+        "path-exists": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
+          "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
+          "dev": true,
+          "requires": {
+            "pinkie-promise": "^2.0.0"
+          }
+        },
+        "path-type": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
+          "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "^4.1.2",
+            "pify": "^2.0.0",
+            "pinkie-promise": "^2.0.0"
+          }
+        },
+        "read-pkg": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
+          "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
+          "dev": true,
+          "requires": {
+            "load-json-file": "^1.0.0",
+            "normalize-package-data": "^2.3.2",
+            "path-type": "^1.0.0"
+          }
+        },
+        "read-pkg-up": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
+          "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
+          "dev": true,
+          "requires": {
+            "find-up": "^1.0.0",
+            "read-pkg": "^1.0.0"
+          }
+        },
+        "strip-bom": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
+          "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
+          "dev": true,
+          "requires": {
+            "is-utf8": "^0.2.0"
+          }
+        }
+      }
     },
     "merge-deep": {
       "version": "3.0.2",
@@ -22640,6 +22779,42 @@
         "minimatch": "3.0.4"
       }
     },
+    "redent": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/redent/-/redent-1.0.0.tgz",
+      "integrity": "sha1-z5Fqsf1fHxbfsggi3W7H9zDCr94=",
+      "dev": true,
+      "requires": {
+        "indent-string": "^2.1.0",
+        "strip-indent": "^1.0.1"
+      },
+      "dependencies": {
+        "get-stdin": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
+          "integrity": "sha1-uWjGsKBDhDJJAui/Gl3zJXmkUP4=",
+          "dev": true
+        },
+        "indent-string": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-2.1.0.tgz",
+          "integrity": "sha1-ji1INIdCEhtKghi3oTfppSBJ3IA=",
+          "dev": true,
+          "requires": {
+            "repeating": "^2.0.0"
+          }
+        },
+        "strip-indent": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-1.0.1.tgz",
+          "integrity": "sha1-DHlipq3vp7vUrDZkYKY4VSrhoKI=",
+          "dev": true,
+          "requires": {
+            "get-stdin": "^4.0.1"
+          }
+        }
+      }
+    },
     "redux": {
       "version": "4.0.5",
       "resolved": "https://artifactory.corp.adobe.com:443/artifactory/api/npm/npmjs/redux/-/redux-4.0.5.tgz",
@@ -23090,6 +23265,15 @@
       "version": "1.6.1",
       "resolved": "https://artifactory.corp.adobe.com:443/artifactory/api/npm/npmjs/repeat-string/-/repeat-string-1.6.1.tgz",
       "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc="
+    },
+    "repeating": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz",
+      "integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
+      "dev": true,
+      "requires": {
+        "is-finite": "^1.0.0"
+      }
     },
     "replace-ext": {
       "version": "1.0.0",
@@ -25035,6 +25219,34 @@
         "babel-plugin-transform-object-rest-spread": "^6.26.0"
       }
     },
+    "strip-css-comments": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-css-comments/-/strip-css-comments-3.0.0.tgz",
+      "integrity": "sha1-elYl7/iisibPiUehElTaluE9rok=",
+      "dev": true,
+      "requires": {
+        "is-regexp": "^1.0.0"
+      }
+    },
+    "strip-css-comments-cli": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/strip-css-comments-cli/-/strip-css-comments-cli-2.0.2.tgz",
+      "integrity": "sha1-8c8Faz8rWpiUJPzyFF7xwlCojCU=",
+      "dev": true,
+      "requires": {
+        "get-stdin": "^5.0.1",
+        "meow": "^3.5.0",
+        "strip-css-comments": "^3.0.0"
+      },
+      "dependencies": {
+        "get-stdin": {
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-5.0.1.tgz",
+          "integrity": "sha1-Ei4WFZHiH/TFJTAwVpPyDmOTo5g=",
+          "dev": true
+        }
+      }
+    },
     "strip-eof": {
       "version": "1.0.0",
       "resolved": "https://artifactory.corp.adobe.com:443/artifactory/api/npm/npmjs/strip-eof/-/strip-eof-1.0.0.tgz",
@@ -25711,6 +25923,12 @@
       "version": "1.1.3",
       "resolved": "https://artifactory.corp.adobe.com:443/artifactory/api/npm/npmjs/trim-lines/-/trim-lines-1.1.3.tgz",
       "integrity": "sha1-g5UUvoJCj9nn7InjUIGv6Pb5MRU="
+    },
+    "trim-newlines": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-1.0.0.tgz",
+      "integrity": "sha1-WIeWa7WCpFA6QetST301ARgVphM=",
+      "dev": true
     },
     "trim-repeated": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -16,8 +16,8 @@
     "node": ">=10"
   },
   "scripts": {
-    "build": "microbundle-crl --no-compress --format modern,cjs",
-    "start": "microbundle-crl watch --no-compress --format modern,cjs",
+    "build": "microbundle-crl --no-compress --format modern,cjs --css-modules false",
+    "start": "microbundle-crl watch --no-compress --format modern,cjs --css-modules false",
     "prepare": "run-s build",
     "storybook": "start-storybook",
     "test": "run-s test:unit test:lint test:build",

--- a/package.json
+++ b/package.json
@@ -16,8 +16,9 @@
     "node": ">=10"
   },
   "scripts": {
-    "build": "microbundle-crl --no-compress --format modern,cjs --css-modules false",
+    "build": "microbundle-crl --no-compress --format modern,cjs --css-modules false && npm run stripcsscomments",
     "start": "microbundle-crl watch --no-compress --format modern,cjs --css-modules false",
+    "stripcsscomments": "cp dist/index.css dist/temp.css && strip-css-comments dist/temp.css > dist/index.css && rm dist/temp.css",
     "prepare": "run-s build",
     "storybook": "start-storybook",
     "test": "run-s test:unit test:lint test:build",
@@ -58,6 +59,7 @@
     "react": "^16.13.1",
     "react-dom": "^16.13.1",
     "react-scripts": "^3.4.1",
+    "strip-css-comments-cli": "^2.0.2",
     "style-loader": "^1.2.1"
   },
   "files": [

--- a/src/ActionButton/index.css
+++ b/src/ActionButton/index.css
@@ -1,3 +1,14 @@
+/*
+Copyright 2020 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
 .spectrum-ActionButton span {
   padding-left: var(
     --spectrum-actionbutton-icon-padding-x,

--- a/src/Heading/index.js
+++ b/src/Heading/index.js
@@ -18,7 +18,13 @@ import { Divider } from '@react-spectrum/divider'
 import { Link } from '../Link'
 
 const Heading1 = ({ children, className, ...props }) => (
-  <h1 className={classNames(className, 'spectrum-Heading--XL spectrum-Heading--light')} {...props}>
+  <h1
+    className={classNames(
+      className,
+      'spectrum-Heading--XL spectrum-Heading--light'
+    )}
+    {...props}
+  >
     {children}
   </h1>
 )

--- a/src/SearchField/index.css
+++ b/src/SearchField/index.css
@@ -1,3 +1,14 @@
+/*
+Copyright 2020 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
 .spectrum-Textfield svg {
   display: block;
   position: absolute;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This PR prevents the mangling of CSS class names and fixes a linting error in Heading.

## Related Issue

#5 

## Motivation and Context

Since we are enhancing some spectrum css classes we can't have the class names mangled when we import this package into templates. 

## How Has This Been Tested?

npm linked this package in parliament-client-template to test the CSS overrides work properly.

## Screenshots (if appropriate):

Mangled css classes:

<img width="1280" alt="Screenshot 2020-07-14 10 58 11" src="https://user-images.githubusercontent.com/353180/87441374-0915b900-c5c1-11ea-9abc-271a9ae7a9c4.png">

Without mangled css classes:

<img width="1267" alt="Screenshot 2020-07-14 10 58 28" src="https://user-images.githubusercontent.com/353180/87441455-1b8ff280-c5c1-11ea-8c6a-cf33db2e8c79.png">

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
