### PR TITLE
Refactor import to remove circular dependency

### DIFF
--- a/src/Menu/Menu.js
+++ b/src/Menu/Menu.js
@@ -13,7 +13,7 @@ governing permissions and limitations under the License.
 import { jsx } from '@emotion/core'
 import PropTypes from 'prop-types'
 
-import { Item } from './'
+import Item from './Item'
 
 import '@spectrum-css/menu'
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Fixes a minor circular dependency bug. Since the main Menu component exports both `Menu.js` and `Item.js` in it's `index.js` file, importing the directory from inside `Menu.js` means that it's importing both `Item.js` and itself.

## Related Issue

Closes #26 

## Motivation and Context

It's a minor bug, but worth fixing to reduce CLI noise during build.

## How Has This Been Tested?

1. Run storybook
1. Navigate to the Menu story
1. Verify story still looks valid
1. Run the build command: `npm run build`
1. Verify no messages about circular dependency

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
