### PR TITLE
Added slugified ids to Headings for page TOCs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24570,9 +24570,9 @@
       }
     },
     "slugify": {
-      "version": "1.4.4",
-      "resolved": "https://registry.npmjs.org/slugify/-/slugify-1.4.4.tgz",
-      "integrity": "sha512-N2+9NJ8JzfRMh6PQLrBeDEnVDQZSytE/W4BTC4fNNPmO90Uu58uNwSlIJSs+lmPgWsaAF79WLhVPe5tuy7spjw=="
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/slugify/-/slugify-1.4.5.tgz",
+      "integrity": "sha512-WpECLAgYaxHoEAJ8Q1Lo8HOs1ngn7LN7QjXgOLbmmfkcWvosyk4ZTXkTzKyhngK640USTZUlgoQJfED1kz5fnQ=="
     },
     "snapdragon": {
       "version": "0.8.2",

--- a/package.json
+++ b/package.json
@@ -89,6 +89,7 @@
     "classnames": "^2.2.6",
     "gatsby": "^2.17.6",
     "node-html-parser": "^1.2.19",
-    "prop-types": "^15.7.2"
+    "prop-types": "^15.7.2",
+    "slugify": "^1.4.5"
   }
 }

--- a/src/Heading/index.js
+++ b/src/Heading/index.js
@@ -16,11 +16,13 @@ import classNames from 'classnames'
 import '@spectrum-css/typography'
 import { Divider } from '@react-spectrum/divider'
 import { Link } from '../Link'
+import slugify from 'slugify'
 
 import './index.css'
 
 const Heading1 = ({ children, className, ...props }) => (
   <h1
+    id={slugify(children, { lower: true })}
     className={classNames(
       className,
       'spectrum-Heading spectrum-Heading--XL spectrum-Heading--light'
@@ -51,6 +53,7 @@ const createHeading = (
   }
   return (
     <HeadingTag
+      id={slugify(children, { lower: true })}
       className={classNames(
         className,
         `spectrum-Heading spectrum-Heading--${styles[level].size}`


### PR DESCRIPTION
## Description

Added `id` attributes to all headings so that the right-side TOC links can navigate using these heading ids (provided by the `tableOfContents.url` node from the markdownTemplates query.

## Motivation and Context

This change makes it possible to navigate a page using the right-side TOC created by the parliament-client-template.

## How Has This Been Tested?

Inspected Headings 1-6 in Storyboard to ensure that each heading had an `id` that was formatted (by slugify) as the lowercase, hyphenated version of the Heading's title, which is what is returned by the graphql query from the `markdownTemplates.js` query in the `parliament-client-template`.

## Screenshots:

![image](https://user-images.githubusercontent.com/1828494/88956437-f6f37600-d262-11ea-87ec-71a40c7c8595.png)


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
