### PR TITLE
Updated TableOfContents component to work with MDX

### DIFF
--- a/src/TableOfContents/index.js
+++ b/src/TableOfContents/index.js
@@ -9,58 +9,107 @@ the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTA
 OF ANY KIND, either express or implied. See the License for the specific language
 governing permissions and limitations under the License.
 */
-import React from 'react'
+
+/** @jsx jsx */
+import { css, jsx } from '@emotion/core'
 import PropTypes from 'prop-types'
-import { parse } from 'node-html-parser'
-import { Heading } from '@react-spectrum/text'
+import { Link } from '../Link'
+import { View } from '@react-spectrum/view'
 
-const stripOuterH1 = function (toc) {
-  let html = ''
-  const root = parse(toc)
-  const headerOneList = root.querySelector('ul')
-  if (headerOneList) {
-    const headerTwoList = headerOneList.querySelector('ul')
-    if (headerTwoList) {
-      html = headerTwoList.toString()
-    }
+import '@spectrum-css/typography'
+import '@spectrum-css/link'
+
+const TableOfContents = ({ tableOfContents }) => {
+  const index = tableOfContents.items && tableOfContents.items.length - 1
+
+  const tableOfContentsItems = {
+    items: tableOfContents.items && tableOfContents.items[index].items
   }
-  return html
-}
 
-/*
-const createToC = (tableOfContents, maxDepth, stripH1) => {
-  const depth = 1
-  const root = parse(tableOfContents)
-}
-*/
-
-const TableOfContents = ({ tableOfContents, depth, stripH1, ...props }) => {
-  // Removing the H1 from the ToC
-  const html = stripH1 ? stripOuterH1(tableOfContents) : tableOfContents
   return (
-    <div
-      style={{
-        height: '70vh',
-        overflowY: 'auto',
-        overflowX: 'hidden'
-      }}
-      {...props}
+    <View
+      elementType='nav'
+      role='navigation'
+      aria-label='Article Outline'
+      marginY='size-400'
     >
-      <Heading level={5}>On this page</Heading>
-      <span className='toc' dangerouslySetInnerHTML={{ __html: html }} />
-    </div>
+      <h4
+        className='spectrum-Detail--L'
+        css={css`
+          color: var(--spectrum-global-color-gray-600);
+        `}
+      >
+        On this page
+      </h4>
+      <span
+        css={css`
+          * {
+            list-style: none;
+            white-space: nowrap;
+            overflow: hidden;
+            text-overflow: ellipsis;
+            text-decoration: none;
+            max-width: 200px;
+          }
+        `}
+      >
+        <ul
+          className='spectrum-Body--M'
+          css={css`
+            margin: 0;
+            padding-left: 0;
+          `}
+        >
+          {tableOfContentsItems.items &&
+            tableOfContentsItems.items.map(renderItem, index)}
+        </ul>
+      </span>
+    </View>
   )
 }
 
+const renderItem = (item, index) => (
+  <li
+    key={index}
+    css={css`
+      margin-top: var(--spectrum-global-dimension-static-size-100);
+      margin-bottom: 0;
+    `}
+  >
+    {item.items ? (
+      <ul
+        css={css`
+          list-style: none;
+          padding-left: var(--spectrum-global-dimension-static-size-200);
+          margin-left: 0;
+          margin-bottom: 0;
+          margin-top: 0;
+        `}
+      >
+        <Link
+          href={item.url}
+          css={css`
+            margin-left: -16px;
+          `}
+        >
+          {item.title}
+        </Link>
+        {item.items.map(renderItem)}
+      </ul>
+    ) : (
+      <Link href={item.url}>{item.title}</Link>
+    )}
+  </li>
+)
+
+// :rocket
+
 TableOfContents.propTypes = {
-  tableOfContents: PropTypes.string,
-  depth: PropTypes.number,
-  stripH1: PropTypes.bool
+  tableOfContents: PropTypes.object
 }
 
 TableOfContents.defaultProps = {
-  tableOfContents: '',
-  depth: 2,
-  stripH1: true
+  tableOfContents: {}
 }
+
 export { TableOfContents }

--- a/src/TableOfContents/stories/TableOfContents.stories.js
+++ b/src/TableOfContents/stories/TableOfContents.stories.js
@@ -18,21 +18,13 @@ export default {
 }
 
 export const Empty = () => {
-  const props = { tableOfContents: '' }
+  const props = { tableOfContents: {} }
   return <TableOfContents {...props} />
 }
 
 export const WithData = () => {
   const props = {
     tableOfContents: mockData.regular
-  }
-  return <TableOfContents {...props} />
-}
-
-export const WithDataStripH1 = () => {
-  const props = {
-    tableOfContents: mockData.regular,
-    stripH1: true
   }
   return <TableOfContents {...props} />
 }
@@ -44,4 +36,13 @@ export const WithTwoH1s = () => {
   return <TableOfContents {...props} />
 }
 
+export const WithDifferentData = () => {
+  const props = {
+    tableOfContents: mockData.moreTestData
+  }
+  return <TableOfContents {...props} />
+}
+
 WithData.story = { name: 'With Data' }
+WithTwoH1s.story = { name: 'With Two+ H1s' }
+WithDifferentData.story = { name: 'With Different Data' }

--- a/src/TableOfContents/stories/mockData.js
+++ b/src/TableOfContents/stories/mockData.js
@@ -10,10 +10,198 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 const mockData = {
-  regular:
-    '<ul>\n<li>\n<p><a href="/CLA-Management.md/#cla-management">CLA Management</a></p>\n<ul>\n<li><a href="/CLA-Management.md/#outbound-clas">Outbound CLAs</a></li>\n<li><a href="/CLA-Management.md/#inbound-clas">Inbound CLAs</a></li>\n</ul>\n</li>\n</ul>',
-  twoH1s:
-    '<ul>\n<li><a href="/README.md/#handbook">handbook</a></li>\n<li><a href="/README.md/#table-of-contents">Table of Contents</a></li>\n</ul>'
+  regular: {
+    items: [
+      {
+        url: '#step-2-add-templates',
+        title: 'Step 2: Add templates',
+        items: [
+          {
+            url: '#template-conventions',
+            title: 'Template conventions'
+          },
+          {
+            url: '#template-configuration',
+            title: 'Template configuration'
+          },
+          {
+            url: '#quote-preview_template',
+            title: 'Quote preview_template',
+            items: [
+              {
+                url: '#attr',
+                title: 'Attributes'
+              },
+              {
+                url: '#ko-style',
+                title: 'KO-Styles'
+              },
+              {
+                url: '#css',
+                title: 'CSS'
+              },
+              {
+                url: '#class',
+                title: 'Class'
+              },
+              {
+                url: '#liveedit',
+                title: 'LiveEdit'
+              },
+              {
+                url: '#event',
+                title: 'Event'
+              }
+            ]
+          },
+          {
+            url: '#quote-master_template',
+            title: 'Quote master_template',
+            items: [
+              {
+                url: '#html',
+                title: 'Html'
+              }
+            ]
+          },
+          {
+            url: '#next',
+            title: 'Next'
+          }
+        ]
+      }
+    ]
+  },
+  twoH1s: {
+    items: [
+      {
+        url: '#Heading 1',
+        title: 'Step 3: Add components (optional)'
+      },
+      {
+        url: '#Another Heading 1',
+        title: 'Step 3: Add components (optional)'
+      },
+      {
+        url: '#And Yet Another Heading 1',
+        title: 'Another Heading1',
+        items: [
+          {
+            url: '#about-components',
+            title: 'About components'
+          },
+          {
+            url: '#component-conventions',
+            title: 'Component conventions'
+          },
+          {
+            url: '#component-configuration',
+            title: 'Component configuration'
+          },
+          {
+            url: '#quote-preview_component',
+            title: 'Quote preview_component',
+            items: [
+              {
+                url: '#extend-from-preview',
+                title: 'Extend from Preview'
+              },
+              {
+                url: '#customize-the-options-menu',
+                title: 'Customize the options menu'
+              }
+            ]
+          },
+          {
+            url: '#quote-master_component',
+            title: 'Quote master_component'
+          },
+          {
+            url: '#next',
+            title: 'Next'
+          }
+        ]
+      }
+    ]
+  },
+  moreTestData: {
+    items: [
+      {
+        url: '#segment-definition-data-structure',
+        title: 'Segment Definition Data Structure',
+        items: [
+          {
+            url: '#terms',
+            title: 'Terms',
+            items: [
+              {
+                url: '#schema',
+                title: 'Schema'
+              },
+              {
+                url: '#attributes',
+                title: 'Attributes'
+              },
+              {
+                url: '#context',
+                title: 'Context'
+              },
+              {
+                url: '#row',
+                title: 'Row'
+              },
+              {
+                url: '#container',
+                title: 'Container'
+              },
+              {
+                url: '#container-set',
+                title: 'Container Set'
+              },
+              {
+                url: '#data-set',
+                title: 'Data Set'
+              }
+            ]
+          },
+          {
+            url: '#schema-functions',
+            title: 'Schema Functions'
+          },
+          {
+            url: '#available-data-comparison-functions',
+            title: 'Available Data Comparison Functions'
+          },
+          {
+            url: '#segment-definition-examples',
+            title: 'Segment Definition Examples',
+            items: [
+              {
+                url: '#example-1',
+                title: 'Example 1'
+              },
+              {
+                url: '#example-2',
+                title: 'Example 2'
+              },
+              {
+                url: '#example-3',
+                title: 'Example 3'
+              },
+              {
+                url: '#example-4',
+                title: 'Example 4'
+              },
+              {
+                url: '#example-5',
+                title: 'Example 5'
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  }
 }
 
 export default mockData


### PR DESCRIPTION
## Description

This PR updates the TableOfContents component to work with Mdx data, which is JSON, not html like it was when only processing markdown files using `gatsby-transformer-markdown`.

**NOTE:** The functionality of this component will be merged into or superseded by the `OnThisPage` component that is part of the `Sprint4-delivery` PR.

## Motivation and Context

This change is necessary so that parliament can process both `mdx` and `md` files. In short, the `tableOfContents` node from the mdx queries returns a JSON object tree, not an HTML string as was the case when processing common markdown files.

## Related PR

MDX support for client template: https://github.com/adobe/parliament-client-template/pull/6

## How Has This Been Tested?

I updated the existing storybook tests for the `TableOfContents` component to provide JSON for the mockData representing the data returned from the `markdownTemplate.js` query in `parliament-client-template`. 

I also did some integration testing within the parliament client template to refine the styling.

## Types of changes

This change will break the current `parliament-client-template` until the client template has been converted to consume `md` **and** `mdx` files. We will need to coordinate these changes.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
