### PR TITLE
Added id attributes to headings so TableOfContents component works for navigation

### DIFF
--- a/package.json
+++ b/package.json
@@ -84,7 +84,8 @@
     "node-html-parser": "^1.2.20",
     "prop-types": "^15.7.2",
     "react": "^16.12.0",
-    "react-dom": "^16.12.0"
+    "react-dom": "^16.12.0",
+    "slugify": "^1.4.5"
   },
   "devDependencies": {
     "@babel/core": "^7.8.4",

--- a/package.json
+++ b/package.json
@@ -84,8 +84,7 @@
     "node-html-parser": "^1.2.20",
     "prop-types": "^15.7.2",
     "react": "^16.12.0",
-    "react-dom": "^16.12.0",
-    "slugify": "^1.4.5"
+    "react-dom": "^16.12.0"
   },
   "devDependencies": {
     "@babel/core": "^7.8.4",

--- a/src/Heading/index.js
+++ b/src/Heading/index.js
@@ -16,21 +16,8 @@ import React from 'react'
 import classNames from 'classnames'
 import '@spectrum-css/typography'
 import { Divider } from '@react-spectrum/divider'
-import { Link } from '../Link'
-import slugify from 'slugify'
 
 const headingSizes = ['XL', 'L', 'M', 'S', 'XS', 'XXS']
-
-const Anchor = ({ id }) => (
-  <span
-    aria-hidden='true'
-    id={id}
-    css={css`
-      position: relative;
-      top: calc(-1 * var(--spectrum-global-dimension-static-size-800));
-    `}
-  />
-)
 
 const createHeading = (
   level,
@@ -39,16 +26,12 @@ const createHeading = (
   const HeadingTag = `h${level}`
   const isHeading1 = level === 1
   const isHeading2 = level === 2
-  const marginLink = `margin-inline-start: var(--spectrum-global-dimension-static-size-${
-    isHeading2 ? '100' : '50'
-  });`
 
   return (
     <React.Fragment>
-      {!isHeading1 && <Anchor id={id} />}
       <HeadingTag
         {...props}
-        id={slugify(children, { lower: true })}
+        id={`${id}`}
         className={classNames(
           className,
           `spectrum-Heading--${headingSizes[level - 1]}`,
@@ -62,29 +45,12 @@ const createHeading = (
           margin-top: var(--spectrum-global-dimension-static-size-300) !important;
           font-size: var(--spectrum-global-dimension-static-size-225);
         }`
-            : `& a {
-          opacity: 0;
-          transition: opacity var(--spectrum-global-animation-duration-100) ease-in-out;
-        }
-
-        &:hover a {
-          opacity: 1;
-        }`}
+            : ``}
 
           ${styles}
         `}
       >
         {children}
-        {!isHeading1 && (
-          <Link
-            href={`#${id}`}
-            css={css`
-              ${marginLink}
-            `}
-          >
-            #
-          </Link>
-        )}
       </HeadingTag>
       {isHeading2 && <Divider marginBottom='size-300' />}
     </React.Fragment>

--- a/src/Heading/index.js
+++ b/src/Heading/index.js
@@ -17,6 +17,7 @@ import classNames from 'classnames'
 import '@spectrum-css/typography'
 import { Divider } from '@react-spectrum/divider'
 import { Link } from '../Link'
+import slugify from 'slugify'
 
 const headingSizes = ['XL', 'L', 'M', 'S', 'XS', 'XXS']
 
@@ -47,6 +48,7 @@ const createHeading = (
       {!isHeading1 && <Anchor id={id} />}
       <HeadingTag
         {...props}
+        id={slugify(children, { lower: true })}
         className={classNames(
           className,
           `spectrum-Heading--${headingSizes[level - 1]}`,

--- a/src/Heading/index.js
+++ b/src/Heading/index.js
@@ -16,8 +16,20 @@ import React from 'react'
 import classNames from 'classnames'
 import '@spectrum-css/typography'
 import { Divider } from '@react-spectrum/divider'
+import { Link } from '../Link'
 
 const headingSizes = ['XL', 'L', 'M', 'S', 'XS', 'XXS']
+
+const Anchor = ({ id }) => (
+  <span
+    aria-hidden='true'
+    id={id}
+    css={css`
+      position: relative;
+      top: calc(-1 * var(--spectrum-global-dimension-static-size-800));
+    `}
+  />
+)
 
 const createHeading = (
   level,
@@ -26,9 +38,13 @@ const createHeading = (
   const HeadingTag = `h${level}`
   const isHeading1 = level === 1
   const isHeading2 = level === 2
+  const marginLink = `margin-inline-start: var(--spectrum-global-dimension-static-size-${
+    isHeading2 ? '100' : '50'
+  });`
 
   return (
     <React.Fragment>
+      {!isHeading1 && <Anchor id={id} />}
       <HeadingTag
         {...props}
         id={`${id}`}
@@ -45,12 +61,29 @@ const createHeading = (
           margin-top: var(--spectrum-global-dimension-static-size-300) !important;
           font-size: var(--spectrum-global-dimension-static-size-225);
         }`
-            : ``}
+            : `& a {
+          opacity: 0;
+          transition: opacity var(--spectrum-global-animation-duration-100) ease-in-out;
+        }
+
+        &:hover a {
+          opacity: 1;
+        }`}
 
           ${styles}
         `}
       >
         {children}
+        {!isHeading1 && (
+          <Link
+            href={`#${id}`}
+            css={css`
+              ${marginLink}
+            `}
+          >
+            #
+          </Link>
+        )}
       </HeadingTag>
       {isHeading2 && <Divider marginBottom='size-300' />}
     </React.Fragment>


### PR DESCRIPTION
## Description

Added `id` attributes to all headings so that the right-side TOC links can navigate using these heading ids (provided by the `tableOfContents.url` node from the markdownTemplates query.

## Motivation and Context

This change makes it possible to navigate a page using the right-side TableOfContents created by the parliament-client-template.

## How Has This Been Tested?

**Storybook:** Inspected Headings 1-6 in Storyboard to ensure that each heading had an `id` that was formatted (by slugify) as the lowercase, hyphenated version of the Heading's title, which is what is returned by the graphql query from the `markdownTemplates.js` query in the `parliament-client-template`.

**Client Template Integration:** I also tested it with the client template against the new TableOfContents control. Works well.

## Screenshots:

![image](https://user-images.githubusercontent.com/1828494/88956437-f6f37600-d262-11ea-87ec-71a40c7c8595.png)


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
