### PR TITLE
🐛  Fix issue with content not scrolling if right rail has focus

### DIFF
--- a/src/Grid/index.js
+++ b/src/Grid/index.js
@@ -40,7 +40,10 @@ const Grid = ({ children, ...props }) => (
 
 const GridHeader = styled.div`
   height: var(--spectrum-global-dimension-size-800);
-  width: auto;
+  width: 100%;
+  position: fixed;
+  background-color: white;
+  z-index: 2;
 
   @media screen and (min-width: 1201px) {
     grid-area: 1 / 1 / 2 / 14;
@@ -60,13 +63,11 @@ const GridContent = styled.main`
 
   @media screen and (min-width: 1201px) {
     grid-area: 2 / 2 / 2 / 11;
-    height: 100vh;
     overflow-y: auto;
     overflow-x: hidden;
   }
   @media screen and (min-width: 768px) and (max-width: 1200px) {
     grid-area: 2 / 2 / 2 / 13;
-    height: 100vh;
     overflow-y: auto;
     overflow-x: hidden;
   }
@@ -101,6 +102,10 @@ const GridFooter = styled.div`
 
 const GridNav = styled.div`
   background-color: var(--spectrum-global-color-gray-75);
+  position: fixed;
+  margin-top: var(--spectrum-global-dimension-size-800);
+  height: 100%;
+
   @media screen and (min-width: 768px) {
     grid-area: 2 / 1 / 4 / 2;
   }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Fix issue with content not scrolling if right rail has focus

## Related Issue

n/a

## Motivation and Context

There's appears to be a bug in Parliament that is causing some user confusion. If my mouse is sitting on the right side of the page (under the "ON THIS PAGE" section), I can't scroll the page. From a user perspective, it seems like there is a problem with the content like it got truncated but if you move your mouse into the page content, you can continue scrolling. 

## How Has This Been Tested?

tested locally using gatsby develop/build/serve

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
