### PR TITLE
💡Fix to ignore `org/repo/branch` structure in manifest path

### DIFF
--- a/src/ManifestUtils/index.js
+++ b/src/ManifestUtils/index.js
@@ -29,14 +29,11 @@ function stripManifestPath(path, { org = '', name = '', branch = '' } = {}) {
   // Normal case with org/name/branch
   const location = path.toLowerCase().indexOf(urlPrefix.toLowerCase())
   if (location > -1) {
-    return path.substring(location + urlPrefix.length)
-  } else if (path.toLowerCase().indexOf(name.toLowerCase() > -1)) {
-    // Exception case with only name in url
-    return path.substring(
-      path.toLowerCase().indexOf(name.toLowerCase()) + name.length
-    )
+    return path.substring(location + urlPrefix.length);
+  } else if (!path.startsWith('/')) {
+    return '/'+path;
   } else {
-    return path
+    return path;
   }
 }
 

--- a/src/ManifestUtils/index.js
+++ b/src/ManifestUtils/index.js
@@ -13,28 +13,23 @@ function stripManifestPath(path, { org = '', name = '', branch = '' } = {}) {
   if (!path) {
     return ''
   }
-  if (path.startsWith('http://') || path.startsWith('https://')) {
+  if (
+    path.startsWith('http://') ||
+    path.startsWith('https://') ||
+    (org === '' && name === '' && branch === '')
+  ) {
     return path
   }
-  let urlPrefix = ''
-  if (org) {
-    urlPrefix += org
-  }
-  if (name) {
-    urlPrefix += urlPrefix !== '' ? '/' + name : name
-  }
-  if (branch) {
-    urlPrefix += urlPrefix !== '' ? '/' + branch : branch
-  }
-  // Normal case with org/name/branch
-  const location = path.toLowerCase().indexOf(urlPrefix.toLowerCase())
-  if (location > -1) {
-    return path.substring(location + urlPrefix.length);
-  } else if (!path.startsWith('/')) {
-    return '/'+path;
-  } else {
-    return path;
-  }
+  const prefix = [org, name, branch]
+  const splitPath = path.split('/').filter((item) => item !== '')
+
+  prefix.map((item) => {
+    if (item.toLocaleLowerCase() === splitPath[0].toLocaleLowerCase()) {
+      splitPath.shift()
+    }
+  })
+
+  return '/' + splitPath.join('/')
 }
 
 function defaultFocus(theObject, selected, urlPrefix) {

--- a/src/ManifestUtils/test/ManifestUtils.test.js
+++ b/src/ManifestUtils/test/ManifestUtils.test.js
@@ -307,6 +307,33 @@ describe('stripManifestPath', () => {
       })
     ).toEqual('https://adobe.io/authentication')
   })
+  it('local reference path without org, repo and branch', () => {
+    expect(
+      stripManifestPath('README.md', {
+        org: 'adobedocs',
+        name: 'stock-api-docs',
+        branch: 'master'
+      })
+    ).toEqual('/README.md')
+  })
+  it('complex local reference path without org, repo and branch', () => {
+    expect(
+      stripManifestPath('docs/reference/openapi.json', {
+        org: 'adobedocs',
+        name: 'stock-api-docs',
+        branch: 'master'
+      })
+    ).toEqual('/docs/reference/openapi.json')
+  })
+  it('complex local reference path leading /', () => {
+    expect(
+      stripManifestPath('/onboarding.md', {
+        org: 'adobedocs',
+        name: 'stock-api-docs',
+        branch: 'master'
+      })
+    ).toEqual('/onboarding.md')
+  })
 })
 
 describe('defaultFocus', () => {

--- a/src/ManifestUtils/test/ManifestUtils.test.js
+++ b/src/ManifestUtils/test/ManifestUtils.test.js
@@ -248,6 +248,15 @@ describe('stripManifestPath', () => {
       })
     ).toEqual('/docs/01-getting-started.md')
   })
+  it('path does not include org, name or branch', () => {
+    expect(
+      stripManifestPath('/docs/01-getting-started.md', {
+        org: 'adobe',
+        name: 'stock-api-docs',
+        branch: 'master'
+      })
+    ).toEqual('/docs/01-getting-started.md')
+  })
   it('remote link with org in url', () => {
     expect(
       stripManifestPath('https://adobe.io/authentication', {

--- a/src/ManifestUtils/test/ManifestUtils.test.js
+++ b/src/ManifestUtils/test/ManifestUtils.test.js
@@ -257,6 +257,38 @@ describe('stripManifestPath', () => {
       })
     ).toEqual('/docs/01-getting-started.md')
   })
+  it('path does not include org, name or branch. No org passed', () => {
+    expect(
+      stripManifestPath('/docs/01-getting-started.md', {
+        name: 'stock-api-docs',
+        branch: 'master'
+      })
+    ).toEqual('/docs/01-getting-started.md')
+  })
+  it('path does not include org, name or branch', () => {
+    expect(
+      stripManifestPath('/docs/01-getting-started.md', {
+        org: 'adobe',
+        branch: 'master'
+      })
+    ).toEqual('/docs/01-getting-started.md')
+  })
+  it('path does not include org, name or branch', () => {
+    expect(
+      stripManifestPath('/docs/01-getting-started.md', {
+        org: 'adobe',
+        name: 'stock-api-docs'
+      })
+    ).toEqual('/docs/01-getting-started.md')
+  })
+  it('path does not include org, name or branch', () => {
+    expect(
+      stripManifestPath('/docs/01-getting-started.md', {
+        org: 'adobe',
+        branch: 'master'
+      })
+    ).toEqual('/docs/01-getting-started.md')
+  })
   it('remote link with org in url', () => {
     expect(
       stripManifestPath('https://adobe.io/authentication', {


### PR DESCRIPTION
Fix to ignore `org/repo/branch` structure in manifest path
## Description

Currently, json or yaml based manifest expects `org/repo/branch` in path, this fix removes a bug and allows to ignore if `org/repo/branch` is not provided in the path.

## Motivation and Context

Currently, json or yaml based manifest expects `org/repo/branch` in path, this fix removes a bug and allows to ignore if `org/repo/branch` is not provided in the path.

## How Has This Been Tested?

tested locally


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
