### PR TITLE
🐛  DEVEP-2353: ActionButtons should open git urls in separate tab

### DIFF
--- a/src/ActionButtons/index.js
+++ b/src/ActionButtons/index.js
@@ -9,37 +9,49 @@ the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTA
 OF ANY KIND, either express or implied. See the License for the specific language
 governing permissions and limitations under the License.
 */
-import React from 'react'
+/** @jsx jsx */
+import { css, jsx } from '@emotion/react'
 import PropTypes from 'prop-types'
 import { ActionButton, Text } from '@adobe/react-spectrum'
 
 import Bug from '@spectrum-icons/workflow/Bug'
 import Edit from '@spectrum-icons/workflow/Edit'
 
-const ActionButtons = ({ gitUrl, filePath, branch, issues, ...props }) => (
+const ActionLink = ({ href, children }) => (
+  <a
+    href={href}
+    css={css`
+      text-decoration: none;
+    `}
+    target='_blank'
+    rel='noopener noreferrer nofollow'
+  >
+    {children}
+  </a>
+)
+
+const ActionButtons = ({
+  gitUrl = '',
+  filePath = '',
+  branch = '',
+  issues,
+  ...props
+}) => (
   <div {...props}>
-    <ActionButton
-      isQuiet
-      onPress={() => {
-        document.location.href = `${gitUrl}/edit/${branch}/${filePath}`
-      }}
-      aria-label='Edit page'
+    <ActionLink href={`${gitUrl}/edit/${branch}/${filePath}`}>
+      <ActionButton isQuiet aria-label='Edit page' excludeFromTabOrder>
+        <Edit size='S' />
+        <Text>Edit this page</Text>
+      </ActionButton>
+    </ActionLink>
+    <ActionLink
+      href={issues || `${gitUrl}/issues/new?body=Issue%20in%20${filePath}`}
     >
-      <Edit size='S' />
-      <Text>Edit this page</Text>
-    </ActionButton>
-    <ActionButton
-      isQuiet
-      onPress={() => {
-        issues
-          ? (document.location.href = issues)
-          : (document.location.href = `${gitUrl}/issues/new?body=Issue%20in%20${filePath}`)
-      }}
-      aria-label='Log issue'
-    >
-      <Bug size='S' />
-      <Text>Log an issue</Text>
-    </ActionButton>
+      <ActionButton isQuiet aria-label='Log issue' excludeFromTabOrder>
+        <Bug size='S' />
+        <Text>Log an issue</Text>
+      </ActionButton>
+    </ActionLink>
   </div>
 )
 
@@ -47,12 +59,6 @@ ActionButtons.propTypes = {
   branch: PropTypes.string,
   filePath: PropTypes.string,
   gitUrl: PropTypes.string
-}
-
-ActionButtons.defaultProps = {
-  branch: '',
-  filePath: '',
-  gitUrl: ''
 }
 
 export { ActionButtons }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Don't use JS to navigate to a new page, use a link instead.

## Related Issue

DEVEP-2353

## Motivation and Context

Properly open external issues and github links in a new tab

## How Has This Been Tested?

- Storybook
- gatsby develop/build/serve

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
