### PR TITLE
🐛  DEVEP-2806: Guard against git being down

### DIFF
--- a/src/Contributors/index.js
+++ b/src/Contributors/index.js
@@ -40,49 +40,29 @@ const Contributors = ({ href = '#', contributors = [], date, ...props }) => {
       {...props}
     >
       <Flex alignItems='center'>
-        <div
-          css={css`
-            display: inline-flex;
-            flex-direction: row-reverse;
-            padding-left: var(--spectrum-global-dimension-static-size-200);
-          `}
-        >
-          {contributors
-            .slice(0, 5)
-            .reverse()
-            .map((contributor, index) => {
-              const name = contributor.name || contributor.login || 'Unknown'
-              const imgUrl = getAvatarUrl(contributor)
-              return (
-                <span
-                  key={index}
-                  className='u-tooltip-showOnHover'
-                  css={css`
-                    margin-left: calc(
-                      -1 * var(--spectrum-global-dimension-static-size-100)
-                    );
-                    position: relative;
-                    width: calc(
-                      var(--spectrum-global-dimension-static-size-400) +
-                        var(--spectrum-global-dimension-static-size-40)
-                    );
-                    height: calc(
-                      var(--spectrum-global-dimension-static-size-400) +
-                        var(--spectrum-global-dimension-static-size-40)
-                    );
-                    border-radius: var(
-                      --spectrum-global-dimension-static-percent-50
-                    );
-                    background: var(--spectrum-global-color-gray-50);
-                  `}
-                >
-                  <Img
-                    alt={name}
-                    src={[
-                      imgUrl,
-                      `https://github.com/images/gravatars/gravatar-user-420.png`
-                    ]}
+        {contributors.length > 0 && (
+          <div
+            css={css`
+              display: inline-flex;
+              flex-direction: row-reverse;
+              padding-left: var(--spectrum-global-dimension-static-size-200);
+            `}
+          >
+            {contributors
+              .slice(0, 5)
+              .reverse()
+              .map((contributor, index) => {
+                const name = contributor.name || contributor.login || 'Unknown'
+                const imgUrl = getAvatarUrl(contributor)
+                return (
+                  <span
+                    key={index}
+                    className='u-tooltip-showOnHover'
                     css={css`
+                      margin-left: calc(
+                        -1 * var(--spectrum-global-dimension-static-size-100)
+                      );
+                      position: relative;
                       width: calc(
                         var(--spectrum-global-dimension-static-size-400) +
                           var(--spectrum-global-dimension-static-size-40)
@@ -94,18 +74,40 @@ const Contributors = ({ href = '#', contributors = [], date, ...props }) => {
                       border-radius: var(
                         --spectrum-global-dimension-static-percent-50
                       );
-                      border: var(--spectrum-global-dimension-static-size-40)
-                        solid var(--spectrum-global-color-gray-50);
+                      background: var(--spectrum-global-color-gray-50);
                     `}
-                  />
-                  <div className='spectrum-Tooltip spectrum-Tooltip--top'>
-                    <span className='spectrum-Tooltip-label'>{name}</span>
-                    <span className='spectrum-Tooltip-tip' />
-                  </div>
-                </span>
-              )
-            })}
-        </div>
+                  >
+                    <Img
+                      alt={name}
+                      src={[
+                        imgUrl,
+                        `https://github.com/images/gravatars/gravatar-user-420.png`
+                      ]}
+                      css={css`
+                        width: calc(
+                          var(--spectrum-global-dimension-static-size-400) +
+                            var(--spectrum-global-dimension-static-size-40)
+                        );
+                        height: calc(
+                          var(--spectrum-global-dimension-static-size-400) +
+                            var(--spectrum-global-dimension-static-size-40)
+                        );
+                        border-radius: var(
+                          --spectrum-global-dimension-static-percent-50
+                        );
+                        border: var(--spectrum-global-dimension-static-size-40)
+                          solid var(--spectrum-global-color-gray-50);
+                      `}
+                    />
+                    <div className='spectrum-Tooltip spectrum-Tooltip--top'>
+                      <span className='spectrum-Tooltip-label'>{name}</span>
+                      <span className='spectrum-Tooltip-tip' />
+                    </div>
+                  </span>
+                )
+              })}
+          </div>
+        )}
         {count > 0 ? (
           <div
             css={css`
@@ -117,7 +119,9 @@ const Contributors = ({ href = '#', contributors = [], date, ...props }) => {
         ) : null}
         <span
           css={css`
-            padding-left: var(--spectrum-global-dimension-static-size-200);
+            padding-left: ${contributors.length > 0
+              ? `var(--spectrum-global-dimension-static-size-200)`
+              : 0};
           `}
         >
           {date && `Last updated ${date}`}

--- a/src/Contributors/stories/Contributors.stories.js
+++ b/src/Contributors/stories/Contributors.stories.js
@@ -105,3 +105,13 @@ export const InvalidImage = () => {
 
   return <Contributors {...props} />
 }
+
+export const EmptyCommitters = () => {
+  const props = {
+    contributors: [],
+    date: 'May 20, 2020',
+    href: ''
+  }
+
+  return <Contributors {...props} />
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Checks to see if the contributors array is populated. If not, it doesn't try to show contributor images.

## Related Issue

DEVEP-2806

## Motivation and Context

On the off hand chance we can't connect to git in order to get the last 5 editors of the files. Instead of showing a bunch of blank space we align the date changed to the left of the container.

## How Has This Been Tested?

storybook tests

## Screenshots (if appropriate):

![Screen Shot 2021-06-23 at 17 14 32](https://user-images.githubusercontent.com/353180/123168829-7d4e1300-d446-11eb-8705-36f7bb9f913d.png)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
