### PR TITLE
style: add outline when tab and sidenav anchor elements are focused

### DIFF
--- a/src/Header/index.css
+++ b/src/Header/index.css
@@ -1,0 +1,14 @@
+/*
+Copyright 2021 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+.spectrum-Tabs-item:focus {
+  outline: auto;
+}

--- a/src/SideNav/index.css
+++ b/src/SideNav/index.css
@@ -9,6 +9,10 @@ the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTA
 OF ANY KIND, either express or implied. See the License for the specific language
 governing permissions and limitations under the License.
 */
+.spectrum-SideNav-itemLink:focus {
+  outline: auto;
+}
+
 .spectrum-SideNav-itemLink svg {
   margin-right: var(
     --spectrum-sidenav-icon-gap,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

* Set `outline: auto;` in the `Tabs` and `SideNav` components' CSS to show focus outline

## Related Issue

* Closes #184 

## Motivation and Context

The "Header" and "SideNav" components render links with their CSS `outline` property set to `none` when the element is in a focused state (which is the default in @spectrum/css AFAICT based on what's [here](https://github.com/adobe/spectrum-css/blob/main/components/sidenav/index.css#L59-L61) and [here](https://github.com/adobe/spectrum-css/blob/main/components/tabs/index.css#L68)). In practice this makes it so that when a user is using keyboard navigation, the UI doesn't reflect when the element is focused. This change makes the focus state of elements in the `Header` and `SideNav` visible by default.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

_WIP_

## Screenshots:

_Before_

<img width="2133" alt="before" src="https://user-images.githubusercontent.com/42074547/134438243-6aa93c76-1b1d-40be-afcb-5a6777cb7a47.png">

_After_

<img width="2133" alt="after" src="https://user-images.githubusercontent.com/42074547/134438281-80aa61c0-e0bb-4d8f-b101-7acba5457a8a.png">

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
