### PR TITLE
Show horizontal table scrollbar only if necessary

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,10 +53,10 @@ yarn test
 
 ### Run Storybook
 
-This project uses [Storybook](http://storybook.js.org/) for testing the look and behavior of its UI components.
+This project uses [Storybook][http://storybook.js.org/] for testing the look and behavior of its UI components.
 
 ```bash
-yarn start-storybook
+yarn storybook
 ```
 
 ## Concurrent Development

--- a/README.md
+++ b/README.md
@@ -53,10 +53,10 @@ yarn test
 
 ### Run Storybook
 
-This project uses [Storybook][http://storybook.js.org/] for testing the look and behavior of its UI components.
+This project uses [Storybook](http://storybook.js.org/) for testing the look and behavior of its UI components.
 
 ```bash
-yarn storybook
+yarn start-storybook
 ```
 
 ## Concurrent Development

--- a/src/Table/index.js
+++ b/src/Table/index.js
@@ -17,7 +17,7 @@ import '@spectrum-css/table'
 
 const Table = ({ children, isQuiet, ...props }) => {
   return (
-    <div style={{ width: '100%', overflowX: 'scroll' }}>
+    <div style={{ width: '100%', overflowX: 'auto' }}>
       <table
         className={classNames([
           'spectrum-Table',


### PR DESCRIPTION
## Description

_Main change_
This pull request proposes setting the [overflow-x](https://www.w3.org/TR/css-overflow-3/#overflow-control) CSS property of the table component to 'auto' to show the scrollbar only when it overflows its parent container.

_Boyscouting_
Furthermore, this pull request includes some boy-scouting changes to fix a link in the README and update the command to spin up the storybook to 'yarn start-storybook'. The old command, 'yarn storybook' did not work for me and, apparently, for many other people that asked about this on Slack. The answer to this question was usually: "Have you tried using 'start-storybook' instead? I took advantage of this pull request to update it.

## Related Issue

N/A

## Motivation and Context

Large tables were made scrollable back in 2021 by setting its [overflow-x](https://www.w3.org/TR/css-overflow-3/#overflow-control) CSS property to 'scroll' https://github.com/adobe/parliament-ui-components/commit/5343d3801335af9e9601e3cc5c9242369e421ae7. While this indeed makes large tables scrollable, setting it to 'scroll' caused a horizontal scrollbar to appear also for smaller tables that do not require scrolling — see grey bar below table in screenshot. The aim of this pull request is to remove that scrollbar for small tables and show it only when necessary.

![image](https://github.com/adobe/parliament-ui-components/assets/12563382/9c485c3c-af3d-4e91-884d-1b09f7af34d1)

## How Has This Been Tested?

This change was tested by manually opening a Parliament page with Google Chrome and updating the CSS property with its dev tools tab. See video demo below.

https://github.com/adobe/parliament-ui-components/assets/12563382/18dd8f54-1a5d-4003-9963-c9a68fd2e5b7

I tested the change locally with the storybook to assert that the change to [src/Table/index.js](https://github.com/adobe/parliament-ui-components/compare/main...Tomasito665:parliament-ui-components:hide_table_scrollbar_when_not_needed?expand=1#diff-25c45d7f73521f0e951a6bd17074b7d4c60303155465e6cf671202398cf1ff34) updates the expected property.

<img width="1061" alt="image" src="https://github.com/adobe/parliament-ui-components/assets/12563382/b1385b99-14b9-4810-90bc-b03e9688e860">

## Screenshots (if appropriate):

See above.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
