### PR TITLE
📝 Update instructions in README to run storybook locally

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ yarn test
 This project uses [Storybook][http://storybook.js.org/] for testing the look and behavior of its UI components.
 
 ```bash
-yarn storybook
+yarn start-storybook
 ```
 
 ## Concurrent Development


### PR DESCRIPTION
## Description

The current README tells the contributor to run `yarn storybook` to spin up Storybook on their local machine. This command does not work for me and crashes with 'ERROR #98124 WEBPACK'. A quick [search on Slack](https://magento.slack.com/archives/CPWPV7CDP/p1632783893074700) reveals that I am not the only contributor experiencing this issue. The [usual response](https://magento.slack.com/archives/CPWPV7CDP/p1632784207075100) seems to be: have you tried running `yarn start-storybook`? This pull request proposes updating the instructions in README to use `yarn start-storybook` from the start, which spins up storybook successfully.

<img width="949" alt="image" src="https://github.com/adobe/parliament-ui-components/assets/12563382/28dda481-bdf9-4117-951f-c035178230ae">

## Related Issue

N/A

## Motivation and Context

New or infrequent contributors (like me) are likely not to remember that one should use `yarn start-storybook` instead of `yarn storybook` to spin up Storybook.

## How Has This Been Tested?

I ran `yarn start-storybook` locally, which successfully spins up Storybook.

## Screenshots (if appropriate):

<img width="1072" alt="image" src="https://github.com/adobe/parliament-ui-components/assets/12563382/d202a5f9-e293-4607-84b5-b1232d2fad6b">

## Types of changes

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [X] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
